### PR TITLE
Add MIDI percussion instrument to autocompletions

### DIFF
--- a/completions.cson
+++ b/completions.cson
@@ -59,7 +59,8 @@
   'kalimba'
   'bagpipes'
   'shenai'
-  'steel-drum'
+  'steel-drum',
+  'percussion'
 ]
 'attributes': [
   'duration'

--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -98,7 +98,7 @@ module.exports =
       completions
 
   buildInstrumentComp: (instr, isInner) ->
-    type: 'insturment'
+    type: 'instrument'
     snippet: if isInner then "#{instr}$1:$2" else "#{instr}$1"
     displayText: instr
     iconHTML: '<i class="icon-unmute"></i>'


### PR DESCRIPTION
This adds the MIDI `percussion` instrument [added in Alda v1.0.0-rc5](https://github.com/alda-lang/alda/commit/03ccd0f705b12724b6f1d2157c5c08f0caeeb0f4?w=1) to the list of autocompletions.

There's also a minor typo fix, though I'm not sure it was affecting anything.

Thanks again for this awesome plugin -- it's great that we have support in all these text editors!
